### PR TITLE
Changed power devices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,13 @@
 domoticz-hyundai-kia plugin
 ChangeLog
 
+20230331 1.1.5
+The power consumed and power generated devices from 1.1.4. are renamed to clearly show that those only show 90-day data as provided by the Hyundai-Kia cloud.
+Two new devices are added to show the all-time totals of the power consumed and power generated.
+To track all-time totals the daily total of today is loaded onto incremental counters.
+To avoid double counting when running multiple times per day, each time it is checked what the current counterToday is, so only the additional increment
+is then added. The plugin should also be run shortly before midnight to collect latest daily total.
+
 20231009 1.1.4
 Add total_power_regenerated device and data update
 Note: this does require latest version of hyundai-kia-connect-api as well, otherwise field will not be present

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ When plugin is activated, more than 30 devices will be automatically added to do
 
 If you want to rename a device, change only the {device name} part, **do not change the {PLUGIN_NAME} - {VEHICLE_NAME} part of device name** because it's used by the plugin to associate device name to a vehicle_name and vehicle_id provided by the cloud. Also, **do not change the name of the ODOMETER device**: leave this device name as original!
 
+Make sure that the plugin is also run shortly before midnight (in addition to the polling intervals configured) by adding a timer setting to the switch device that can be use to force a data update. For example add a timer that sets the switch to status "On" every weekday at 23:57.
+
 Then, enter Domoticz panel, go to Setup -> Hardware and enable the Hyundai Kia connect plugin specifying the Hyundai or Kia account credential: up to 4 vehicles associated to this account can be shown automatically on Domoticz.
 
 Please note that there are some restrictions on the number of daily access to the cloud... for example EU customers cannot connect more than 200 times/day


### PR DESCRIPTION
Renamed existing power devices to indicate 90 day data. Added new devices to track all-time power consumed and generated.
Added a note in the installation instructions to add a timer to the force-data-update switch.