### PR TITLE
Fix update target charging levels in Domoticz

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -457,16 +457,24 @@ class BasePlugin:
         k='EVLIMITAC'; dev=DEVS[k]; var=getattr(v, 'ev_charge_limits_ac', None)
         if var==None: var=getattr(v, '_ev_charge_limits.ac', None)
         if var != None:
-            nValue=var
             if self.verbose: Domoticz.Status(f"{k}={var}")
-            unit=base+dev[0]; self.getDevID(unit); self.update(unit, nValue, str(nValue))
+            nVar=int(var)
+            nValue=2
+            sValue=var
+            if nVar==100: nValue=1
+            if nVar==0: nValue=0
+            unit=base+dev[0]; self.getDevID(unit); self.update(unit, nValue, sValue)
             
         k='EVLIMITDC'; dev=DEVS[k]; var=getattr(v, 'ev_charge_limits_dc', None)
         if var==None: var=getattr(v, '_ev_charge_limits.dc', None)
         if var != None:
-            nValue=var
             if self.verbose: Domoticz.Status(f"{k}={var}")
-            unit=base+dev[0]; self.getDevID(unit); self.update(unit, nValue, str(nValue))
+            nVar=int(var)
+            nValue=2
+            sValue=var
+            if nVar==100: nValue=1
+            if nVar==0: nValue=0
+            unit=base+dev[0]; self.getDevID(unit); self.update(unit, nValue, sValue)
             
         k='FUELLEVEL'; dev=DEVS[k]; var=getattr(v, 'fuel_level', None)
         if var != None:


### PR DESCRIPTION
It seems there is an error in updating the AC and DC charging limits in Domoticz from the values obtained via the API.

nValue must be 0 when level is 0
nValue must be 1 when level is 100
nValue must be 2 when level is something in between

